### PR TITLE
指定使用UTF-8格式打开配置文件

### DIFF
--- a/py/main/get_seat.py
+++ b/py/main/get_seat.py
@@ -48,7 +48,7 @@ def read_config_from_yaml():
         BARK_URL, ANPUSH_TOKEN, ANPUSH_CHANNEL, PUSH_METHOD
     current_dir = os.path.dirname(os.path.abspath(__file__))  # 获取当前文件所在的目录的绝对路径
     config_file_path = os.path.join(current_dir, 'config.yml')  # 将文件名与目录路径拼接起来
-    with open(config_file_path, 'r') as yaml_file:
+    with open(config_file_path, "r", encoding="utf-8") as yaml_file: # 指定为UTF-8格式打开文件
         config = yaml.safe_load(yaml_file)
         CHANNEL_ID = config.get('CHANNEL_ID', '')
         TELEGRAM_BOT_TOKEN = config.get('TELEGRAM_BOT_TOKEN', '')


### PR DESCRIPTION
今天第一次用，打开文件报错了
应该是编码问题
问了下`nakai！`师哥
改了文件打开方式就好了
指定使用UTF-8格式打开
下面是当时的报错日志
```
(.venv) PS F:\Github-projects\GitHub-very-good\qfnuLibraryBook\py\main> python .\get_seat.py
Traceback (most recent call last):
  File "F:\Github-projects\GitHub-very-good\qfnuLibraryBook\py\main\get_seat.py", line 546, in <module>
    read_config_from_yaml()
  File "F:\Github-projects\GitHub-very-good\qfnuLibraryBook\py\main\get_seat.py", line 52, in read_config_from_yaml
    config = yaml.safe_load(yaml_file)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "F:\Github-projects\GitHub-very-good\qfnuLibraryBook\.venv\Lib\site-packages\yaml\__init__.py", line 125, in safe_load
    return load(stream, SafeLoader)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "F:\Github-projects\GitHub-very-good\qfnuLibraryBook\.venv\Lib\site-packages\yaml\__init__.py", line 79, in load
    loader = Loader(stream)
             ^^^^^^^^^^^^^^
  File "F:\Github-projects\GitHub-very-good\qfnuLibraryBook\.venv\Lib\site-packages\yaml\loader.py", line 34, in __init__
    Reader.__init__(self, stream)
  File "F:\Github-projects\GitHub-very-good\qfnuLibraryBook\.venv\Lib\site-packages\yaml\reader.py", line 85, in __init__
    self.determine_encoding()
  File "F:\Github-projects\GitHub-very-good\qfnuLibraryBook\.venv\Lib\site-packages\yaml\reader.py", line 124, in determine_encoding
    self.update_raw()
  File "F:\Github-projects\GitHub-very-good\qfnuLibraryBook\.venv\Lib\site-packages\yaml\reader.py", line 178, in update_raw
    data = self.stream.read(size)
           ^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'gbk' codec can't decode byte 0xaf in position 328: illegal multibyte sequence
```